### PR TITLE
feat: implement Django logging integration and add example

### DIFF
--- a/VersaLog/integrations/django.py
+++ b/VersaLog/integrations/django.py
@@ -1,5 +1,19 @@
-from .generic import setup_logging
+import logging
+from ..handler import VersaLogHandle
 
 
 def setup_django_logging(versalog):
-    setup_logging(versalog)
+    handler = VersaLogHandler(versalog)
+
+    root = logging.getLogger()
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    root.setLevel(logging.NOTSET)
+    root.addHandler(handler)
+
+    for name in ["django", "django.request", "django.server", "django.db.backends"]:
+        logger = logging.getLogger(name)
+        for h in logger.handlers[:]:
+            logger.removeHandler(h)
+        logger.propagate = True
+        logger.setLevel(logging.NOTSET)

--- a/examples/django_log.py
+++ b/examples/django_log.py
@@ -1,0 +1,19 @@
+# Example: Using VersaLog with Django
+#
+# In your settings.py, add:
+#
+#   LOGGING_CONFIG = None  # Disable Django's default logging config
+#
+#   from VersaLog import VersaLog, setup_django_logging
+#   log = VersaLog(enum="detailed", show_tag=True, tag="Django")
+#   setup_django_logging(log)
+
+# views.py
+from django.http import JsonResponse
+import logging
+
+logger = logging.getLogger(__name__)
+
+def index(request):
+    logger.info("Hello from Django")
+    return JsonResponse({"msg": "ok"})


### PR DESCRIPTION

## What this PR does
- Implements `setup_django_logging()` in `integrations/django.py`
- Adds `examples/django_log.py` with a minimal usage example

## Changes
- `VersaLog/integrations/django.py`: Replace placeholder with full Django logging setup (removes Django-specific handlers and routes logs through VersaLogHandler)
- `examples/django_log.py`: Add example showing settings.py configuration and views.py usage